### PR TITLE
nix update image path during build

### DIFF
--- a/package.nix
+++ b/package.nix
@@ -8,5 +8,6 @@ stdenvNoCC.mkDerivation {
     mkdir -p $out/share/plymouth/themes/mac-style
     cp -r mac-style $out/share/plymouth/themes/
     chmod +x $out/share/plymouth/themes/mac-style/mac-style.plymouth
+    substituteInPlace $out/share/plymouth/themes/mac-style/mac-style.plymouth --replace '@IMAGES@' "$out/share/plymouth/themes/mac-style/images/"
   '';
 }

--- a/src/mac-style/mac-style.plymouth
+++ b/src/mac-style/mac-style.plymouth
@@ -4,7 +4,7 @@ Description=Boot animation with the NixOS logo, inspired by the boot animation o
 ModuleName=two-step
 
 [two-step]
-ImageDir=/etc/plymouth/themes/mac-style/images
+ImageDir=@IMAGES@
 DialogHorizontalAlignment=.5
 DialogVerticalAlignment=.5
 TitleHorizontalAlignment=.5


### PR DESCRIPTION
### Issue:
In the current configuration, the two-step.so plugin attempts to load images from /etc/plymouth/themes/mac-style/images, but fails to find them. As a result, NixOS falls back to the default Plymouth theme.

### This PR provides fix to that problem